### PR TITLE
Issue#153 - Fix query in userModel

### DIFF
--- a/src/models/userModel.ts
+++ b/src/models/userModel.ts
@@ -263,13 +263,20 @@ export class UserModel extends Model {
     (userID : string, companyID : string) : Promise<Object> {
         return new Promise((resolve : (data : boolean) => void,
                             reject : (error : Object) => void) => {
-            this.model.find(
+            this.model.findOne(
                 {_id: userID, company: companyID},
-                (error : Object, numberOfUsers : number) => {
+                (error : Object, person : Object) => {
                     if (error) {
                         reject(error);
                     } else {
-                        resolve(numberOfUsers > 0);
+
+                        let res : boolean = false;
+                        if (person != undefined) {
+
+                            res = true;
+                        }
+
+                        resolve(res);
                     }
                 });
         });


### PR DESCRIPTION
*Numero del Task/Issue correlato/a*: #153 

*Breve descrizione della soluzione adottata*:
Fixato il problema per cui usando `find` non veniva trovato alcun membro in una company, quando questo non era vero. Utilizzo di `findOne` che e' piu' funzionale a quando deve fare il metodo.